### PR TITLE
fix(mapview, sceneview): prevent zooming to graphics

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -39,12 +39,6 @@ const MapView = ({ graphics }: MapViewProps) => {
       const loadGraphics = async () => {
         if (graphics) {
           view.graphics = graphics;
-          await view.when();
-          view.goTo(graphics).catch((error) => {
-            if (error.name !== "AbortError") {
-              console.error(error);
-            }
-          });
         }
       };
       loadGraphics();

--- a/src/components/SceneView.tsx
+++ b/src/components/SceneView.tsx
@@ -39,12 +39,6 @@ const SceneView = ({ graphics }: SceneViewProps) => {
       const loadGraphics = async () => {
         if (graphics) {
           view.graphics = graphics;
-          await view.when();
-          view.goTo(graphics).catch((error) => {
-            if (error.name !== "AbortError") {
-              console.error(error);
-            }
-          });
         }
       };
       loadGraphics();

--- a/src/components/lib/mapview.ts
+++ b/src/components/lib/mapview.ts
@@ -1,13 +1,14 @@
 import Basemap from "@arcgis/core/Basemap";
 import type Graphic from "@arcgis/core/Graphic";
 import ArcMap from "@arcgis/core/Map";
+import Viewpoint from "@arcgis/core/Viewpoint";
 import type Collection from "@arcgis/core/core/Collection";
 import VectorTileLayer from "@arcgis/core/layers/VectorTileLayer";
 import ArcMapView from "@arcgis/core/views/MapView";
 import BasemapGallery from "@arcgis/core/widgets/BasemapGallery";
 import LocalBasemapsSource from "@arcgis/core/widgets/BasemapGallery/support/LocalBasemapsSource";
 import Expand from "@arcgis/core/widgets/Expand";
-import { point } from "./geometry";
+import { polygon } from "./geometry";
 
 const blankBasemapVectorTileLayer = new VectorTileLayer({
   portalItem: {
@@ -26,10 +27,13 @@ const map = new ArcMap({
   basemap: "gray-vector"
 });
 
+const viewpoint = new Viewpoint({
+  targetGeometry: polygon.extent.expand(1.5)
+});
+
 const view = new ArcMapView({
-  center: point,
   map,
-  zoom: 18
+  viewpoint
 });
 
 const localBasemapsSource = new LocalBasemapsSource({

--- a/src/components/lib/sceneview.ts
+++ b/src/components/lib/sceneview.ts
@@ -1,68 +1,73 @@
 import Basemap from "@arcgis/core/Basemap";
 import type Graphic from "@arcgis/core/Graphic";
 import ArcMap from "@arcgis/core/Map";
+import Viewpoint from "@arcgis/core/Viewpoint";
 import type Collection from "@arcgis/core/core/Collection";
 import VectorTileLayer from "@arcgis/core/layers/VectorTileLayer";
 import ArcSceneView from "@arcgis/core/views/SceneView";
 import BasemapGallery from "@arcgis/core/widgets/BasemapGallery";
 import LocalBasemapsSource from "@arcgis/core/widgets/BasemapGallery/support/LocalBasemapsSource";
 import Expand from "@arcgis/core/widgets/Expand";
-import { point } from "./geometry";
+import { polygon } from "./geometry";
+
+const blankBasemapVectorTileLayer = new VectorTileLayer({
+  portalItem: {
+    id: "da7c2aa6b22a439fae31294413b5bc62"
+  }
+});
+
+const blankBasemap = new Basemap({
+  baseLayers: [blankBasemapVectorTileLayer],
+  thumbnailUrl:
+    "https://jsapi.maps.arcgis.com/sharing/rest/content/items/da7c2aa6b22a439fae31294413b5bc62/info/thumbnail/thumbnail1660688993675.png",
+  title: "Blank"
+});
+
+const map = new ArcMap({
+  basemap: "gray-vector"
+});
+
+const viewpoint = new Viewpoint({
+  targetGeometry: polygon.extent.expand(1.5)
+});
+
+const view = new ArcSceneView({
+  map,
+  viewpoint
+});
+
+const localBasemapsSource = new LocalBasemapsSource({
+  basemaps: [
+    blankBasemap,
+    Basemap.fromId("satellite"),
+    Basemap.fromId("hybrid"),
+    Basemap.fromId("dark-gray-vector"),
+    Basemap.fromId("gray-vector"),
+    Basemap.fromId("streets-vector"),
+    Basemap.fromId("streets-night-vector"),
+    Basemap.fromId("streets-navigation-vector"),
+    Basemap.fromId("topo-vector"),
+    Basemap.fromId("streets-relief-vector")
+  ]
+});
+
+const basemapGallery = new BasemapGallery({
+  view,
+  source: localBasemapsSource
+});
+
+const basemapGalleryExpand = new Expand({
+  view,
+  content: basemapGallery
+});
+
+view.ui.add(basemapGalleryExpand, {
+  position: "top-left"
+});
 
 export const createSceneView = async (parentElement: HTMLDivElement, graphics?: Collection<Graphic>) => {
-  const blankBasemapVectorTileLayer = new VectorTileLayer({
-    portalItem: {
-      id: "da7c2aa6b22a439fae31294413b5bc62"
-    }
-  });
-
-  const blankBasemap = new Basemap({
-    baseLayers: [blankBasemapVectorTileLayer],
-    thumbnailUrl:
-      "https://jsapi.maps.arcgis.com/sharing/rest/content/items/da7c2aa6b22a439fae31294413b5bc62/info/thumbnail/thumbnail1660688993675.png",
-    title: "Blank"
-  });
-
-  const map = new ArcMap({
-    basemap: "gray-vector"
-  });
-
-  const view = new ArcSceneView({
-    center: point,
-    map,
-    scale: 1000
-  });
-
-  const localBasemapsSource = new LocalBasemapsSource({
-    basemaps: [
-      blankBasemap,
-      Basemap.fromId("satellite"),
-      Basemap.fromId("hybrid"),
-      Basemap.fromId("dark-gray-vector"),
-      Basemap.fromId("gray-vector"),
-      Basemap.fromId("streets-vector"),
-      Basemap.fromId("streets-night-vector"),
-      Basemap.fromId("streets-navigation-vector"),
-      Basemap.fromId("topo-vector"),
-      Basemap.fromId("streets-relief-vector")
-    ]
-  });
-
-  const basemapGallery = new BasemapGallery({
-    view,
-    source: localBasemapsSource
-  });
-
-  const basemapGalleryExpand = new Expand({
-    view,
-    content: basemapGallery
-  });
-
-  view.ui.add(basemapGalleryExpand, {
-    position: "top-left"
-  });
-
   view.container = parentElement;
+  view.viewpoint = viewpoint;
   view.graphics = graphics as Collection<Graphic>;
   return view;
 };


### PR DESCRIPTION
Prevents zooming to graphics after property changes.  I haven't figured out a way to maintain the extent in sceneview.ts because when the container property is modified in a SceneView the view is reinitialized. This may be improved with an update to the JavaScript API.

Refs: #5